### PR TITLE
Fix name=null

### DIFF
--- a/nsys2json.py
+++ b/nsys2json.py
@@ -315,7 +315,7 @@ def parse_all_events(conn: sqlite3.Connection, strings: dict, activities=None, e
     if ActivityType.NVTX_KERNEL in activities:
         for nvtx_event, (kernel_start_time, kernel_end_time) in nvtx_kernel_event_map.items():
             event = {
-                "name": nvtx_event["text"],
+                "name": nvtx_event["text"] or "",
                 "ph": "X", # Complete Event (Begin + End event)
                 "cat": "nvtx-kernel",
                 "ts": munge_time(kernel_start_time),


### PR DESCRIPTION
Sometimes the dumped results have name == null. In that case chrome refuses to load the trace:
![image](https://github.com/user-attachments/assets/9fbea3c6-da3d-4efd-953c-09bf94da5fdd)


Using an empty string fixes it.